### PR TITLE
Remove `css` and `js` from response attachments.

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -10,6 +10,7 @@ use Drupal\Core\Template\Loader\FilesystemLoader;
 use Retrofit\Drupal\Language\GlobalLanguageContentSetter;
 use Retrofit\Drupal\Menu\MenuLinkManager;
 use Retrofit\Drupal\ParamConverter\PageArgumentsConverter;
+use Retrofit\Drupal\Render\RetrofitHtmlResponseAttachmentsProcessor;
 use Retrofit\Drupal\Routing\HookMenuRegistry;
 use Retrofit\Drupal\Routing\HookMenuRoutes;
 use Retrofit\Drupal\Template\RetrofitExtension;
@@ -80,6 +81,10 @@ class Provider extends ServiceProviderBase
               ->addArgument(new Reference(HookPermissions::class . '.inner'))
               ->addArgument(new Reference('module_handler'));
         }
+
+        $container->register(RetrofitHtmlResponseAttachmentsProcessor::class)
+            ->setDecoratedService('html_response.attachments_processor')
+            ->addArgument(new Reference(RetrofitHtmlResponseAttachmentsProcessor::class . '.inner'));
     }
 
     public function alter(ContainerBuilder $container)

--- a/src/Render/RetrofitHtmlResponseAttachmentsProcessor.php
+++ b/src/Render/RetrofitHtmlResponseAttachmentsProcessor.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Retrofit\Drupal\Render;
+
+use Drupal\Core\Render\AttachmentsInterface;
+use Drupal\Core\Render\AttachmentsResponseProcessorInterface;
+
+final class RetrofitHtmlResponseAttachmentsProcessor implements AttachmentsResponseProcessorInterface
+{
+    public function __construct(
+        private readonly AttachmentsResponseProcessorInterface $inner,
+    ) {
+    }
+
+    public function processAttachments(AttachmentsInterface $response)
+    {
+        $attachments = $response->getAttachments();
+        // @todo log these removals?
+        // @todo what about `settings` now `drupalSettings.
+        unset($attachments['css'], $attachments['js']);
+        $response->setAttachments($attachments);
+        return $this->inner->processAttachments($response);
+    }
+}

--- a/tests/src/Integration/Template/HookThemeTest.php
+++ b/tests/src/Integration/Template/HookThemeTest.php
@@ -55,9 +55,6 @@ final class HookThemeTest extends IntegrationTestCase
 
     public function testThemingExampleListPage(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('You are not allowed to use css in #attached.');
-
         $this->setUpCurrentUser([], ['access content']);
         $this->doRequest(Request::create('/examples/theming_example/theming_example_list_page'));
     }


### PR DESCRIPTION
fixes #10
